### PR TITLE
[FlaxSpeechEncoderDecoder] Fix input shape bug in weights init

### DIFF
--- a/models/modeling_flax_speech_encoder_decoder.py
+++ b/models/modeling_flax_speech_encoder_decoder.py
@@ -223,10 +223,14 @@ class FlaxSpeechEncoderDecoderModule(nn.Module):
         else:
             self.enc_to_dec_proj = None
 
-    def _get_feat_extract_output_lengths(self, input_lengths: Union[jnp.ndarray, int]):
+    def _get_feat_extract_output_lengths(
+        self, input_lengths: Union[jnp.ndarray, int], add_adapter: Optional[bool] = None
+    ):
         """
         Computes the output length of the convolutional layers
         """
+
+        add_adapter = self.config.encoder.add_adapter if add_adapter is None else add_adapter
 
         def _conv_out_length(input_length, kernel_size, stride):
             # 1D convolutional layer output length formula taken
@@ -235,6 +239,10 @@ class FlaxSpeechEncoderDecoderModule(nn.Module):
 
         for kernel_size, stride in zip(self.config.encoder.conv_kernel, self.config.encoder.conv_stride):
             input_lengths = _conv_out_length(input_lengths, kernel_size, stride)
+
+        if add_adapter:
+            for _ in range(self.config.encoder.num_adapter_layers):
+                input_lengths = _conv_out_length(input_lengths, 1, self.config.encoder.adapter_stride)
 
         return input_lengths
 
@@ -429,8 +437,10 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
         )
         return unfreeze(init_variables["cache"])
 
-    def _get_feat_extract_output_lengths(self, input_lengths: Union[jnp.ndarray, int]):
-        return self.module._get_feat_extract_output_lengths(input_lengths)
+    def _get_feat_extract_output_lengths(
+        self, input_lengths: Union[jnp.ndarray, int], add_adapter: Optional[bool] = None
+    ):
+        return self.module._get_feat_extract_output_lengths(input_lengths, add_adapter=add_adapter)
 
     @add_start_docstrings(SPEECH_ENCODER_DECODER_ENCODE_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=FlaxBaseModelOutput, config_class=_CONFIG_FOR_DOC)


### PR DESCRIPTION
Mirrors https://github.com/huggingface/transformers/pull/16728

The tuple `input_shape` is required in the init method of the FlaxSpeechEncoderDecoderModel in order to initialise the model weights - one must specify these input shapes to enable JAX to trace through the model dimensions.
This tuple consists of two entries: the encoder and decoder input lengths. Speech encoders almost always downsample the sequence length dimension. Given an encoder input length, the decoder input length is computed through a convolutional formula. This convolutional formula should take into consideration two convolutional based modules:

Feature extractor
Adapter module (optional)
Currently, only the first of these two convolutional based modules is accounted for. This PR amends the model script to account for the second of the two, i.e. the adapter module.