### PR TITLE
[feat] Save and use feature encoder outputs during training

### DIFF
--- a/models/modeling_flax_speech_encoder_decoder.py
+++ b/models/modeling_flax_speech_encoder_decoder.py
@@ -263,8 +263,10 @@ class FlaxSpeechEncoderDecoderModule(nn.Module):
         decoder_attention_mask,
         decoder_position_ids,
         encoder_outputs=None,
+        extract_features=None,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
+        output_features: bool = False,
         return_dict: bool = True,
         deterministic: bool = True,
         freeze_feature_encoder: bool = False,
@@ -273,12 +275,17 @@ class FlaxSpeechEncoderDecoderModule(nn.Module):
             encoder_outputs = self.encoder(
                 inputs,
                 attention_mask=attention_mask,
+                extract_features=extract_features,
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
+                output_features=output_features,
                 return_dict=return_dict,
                 deterministic=deterministic,
                 freeze_feature_encoder=freeze_feature_encoder,
             )
+
+        if output_features:
+            return encoder_outputs
 
         encoder_hidden_states = encoder_outputs[0]
 
@@ -448,8 +455,10 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
         self,
         inputs: jnp.ndarray,
         attention_mask: Optional[jnp.ndarray] = None,
+        extract_features: Optional[jnp.ndarray] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        output_features: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         train: bool = False,
         freeze_feature_encoder: bool = False,
@@ -481,6 +490,9 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
         if attention_mask is None:
             attention_mask = jnp.ones_like(inputs, dtype="i4")
 
+        if extract_features is not None:
+            extract_features = jnp.array(extract_features, dtype="f4")
+
         # Handle any PRNG if needed
         rngs = {}
         if dropout_rng is not None:
@@ -494,8 +506,10 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
             {"params": params or self.params},
             inputs=jnp.array(inputs, dtype="f4"),
             attention_mask=jnp.array(attention_mask, dtype="i4"),
+            extract_features=extract_features,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            output_features=output_features,
             return_dict=return_dict,
             deterministic=not train,
             freeze_feature_encoder=freeze_feature_encoder,
@@ -503,7 +517,7 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
             method=_encoder_forward,
         )
 
-        if return_dict:
+        if return_dict and not output_features:
             outputs = FlaxBaseModelOutput(
                 last_hidden_state=outputs.last_hidden_state,
                 hidden_states=outputs.hidden_states,
@@ -643,11 +657,13 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
         self,
         inputs: jnp.ndarray,
         attention_mask: Optional[jnp.ndarray] = None,
+        extract_features: Optional[jnp.ndarray] = None,
         decoder_input_ids: Optional[jnp.ndarray] = None,
         decoder_attention_mask: Optional[jnp.ndarray] = None,
         decoder_position_ids: Optional[jnp.ndarray] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        output_features: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         train: bool = False,
         freeze_feature_encoder: bool = False,
@@ -689,6 +705,9 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
         if attention_mask is None:
             attention_mask = jnp.ones_like(inputs, dtype="i4")
 
+        if extract_features is not None:
+            extract_features = jnp.array(extract_features, dtype="f4")
+
         # prepare decoder inputs
         if decoder_input_ids is None:
             raise ValueError(
@@ -709,11 +728,13 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
             {"params": params or self.params},
             inputs=jnp.array(inputs, dtype="f4"),
             attention_mask=jnp.array(attention_mask, dtype="i4"),
+            extract_features=extract_features,
             decoder_input_ids=jnp.array(decoder_input_ids, dtype="i4"),
             decoder_attention_mask=jnp.array(decoder_attention_mask, dtype="i4"),
             decoder_position_ids=jnp.array(decoder_position_ids, dtype="i4"),
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            output_features=output_features,
             return_dict=return_dict,
             deterministic=not train,
             freeze_feature_encoder=freeze_feature_encoder,

--- a/models/modeling_flax_speech_encoder_decoder.py
+++ b/models/modeling_flax_speech_encoder_decoder.py
@@ -706,7 +706,10 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
             attention_mask = jnp.ones_like(inputs, dtype="i4")
 
         if extract_features is not None:
+            inputs = None  # we can omit passing the inputs to the model to save memory
             extract_features = jnp.array(extract_features, dtype="f4")
+        else:
+            inputs = jnp.array(inputs, dtype="f4")
 
         # prepare decoder inputs
         if decoder_input_ids is None:
@@ -726,7 +729,7 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
 
         return self.module.apply(
             {"params": params or self.params},
-            inputs=jnp.array(inputs, dtype="f4"),
+            inputs=inputs,
             attention_mask=jnp.array(attention_mask, dtype="i4"),
             extract_features=extract_features,
             decoder_input_ids=jnp.array(decoder_input_ids, dtype="i4"),

--- a/tests/check_save_feature_encoder_output.ipynb
+++ b/tests/check_save_feature_encoder_output.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b1db3741-29dc-4d1f-943c-ecf2ede5ad66",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sanchitgandhi/venv/lib/python3.8/site-packages/jax/_src/lib/__init__.py:33: UserWarning: JAX on Mac ARM machines is experimental and minimally tested. Please see https://github.com/google/jax/issues/5501 in the event of problems.\n",
+      "  warnings.warn(\"JAX on Mac ARM machines is experimental and minimally tested. \"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import FlaxSpeechEncoderDecoderModel\n",
+    "from models.modeling_flax_speech_encoder_decoder import FlaxSpeechEncoderDecoderModel as CustomFlaxSpeechEncoderDecoderModel\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d67ee694-b5e6-4c98-92f1-3f214500cf55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encoder_id = 'hf-internal-testing/tiny-random-wav2vec2'\n",
+    "decoder_id = 'hf-internal-testing/tiny-random-bart'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5b30237b-080d-4447-a19b-4f11c11603b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n",
+      "Some weights of the model checkpoint at hf-internal-testing/tiny-random-wav2vec2 were not used when initializing FlaxWav2Vec2Model: {('quantizer', 'weight_proj', 'bias'), ('lm_head', 'bias'), ('project_q', 'bias'), ('quantizer', 'codevectors'), ('quantizer', 'weight_proj', 'kernel'), ('lm_head', 'kernel'), ('project_hid', 'bias'), ('project_q', 'kernel'), ('project_hid', 'kernel')}\n",
+      "- This IS expected if you are initializing FlaxWav2Vec2Model from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing FlaxWav2Vec2Model from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "Some weights of FlaxWav2Vec2Model were not initialized from the model checkpoint at hf-internal-testing/tiny-random-wav2vec2 and are newly initialized: {('feature_extractor', 'conv_layers', '2', 'layer_norm', 'bias'), ('feature_extractor', 'conv_layers', '1', 'layer_norm', 'scale'), ('feature_extractor', 'conv_layers', '2', 'layer_norm', 'scale'), ('feature_extractor', 'conv_layers', '1', 'layer_norm', 'bias')}\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n",
+      "You passed along `num_labels=3` with an incompatible id to label map: {'0': 'LABEL_0', '1': 'LABEL_1'}. The number of labels wil be overwritten to 2.\n",
+      "Some weights of the model checkpoint at hf-internal-testing/tiny-random-bart were not used when initializing FlaxBartForCausalLM: {('encoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('decoder', 'layers', '1', 'fc1', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn_layer_norm', 'scale'), ('model', 'encoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'final_layer_norm', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn_layer_norm', 'bias'), ('encoder', 'layers', '0', 'fc1', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('model', 'shared', 'kernel'), ('shared', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn_layer_norm', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'embed_tokens', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('final_logits_bias',), ('decoder', 'embed_tokens', 'embedding'), ('model', 'encoder', 'layernorm_embedding', 'kernel'), ('encoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn_layer_norm', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '1', 'fc2', 'bias'), ('encoder', 'embed_tokens', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'final_layer_norm', 'bias'), ('encoder', 'layernorm_embedding', 'kernel'), ('decoder', 'layers', '0', 'final_layer_norm', 'scale'), ('lm_head', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'final_layer_norm', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'out_proj', 'bias'), ('encoder', 'layers', '1', 'fc2', 'bias'), ('model', 'encoder', 'layers', '1', 'final_layer_norm', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('decoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'fc2', 'kernel'), ('decoder', 'layers', '0', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'fc1', 'kernel'), ('model', 'encoder', 'layernorm_embedding', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'k_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '1', 'fc2', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '0', 'fc2', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('decoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn_layer_norm', 'scale'), ('encoder', 'layernorm_embedding', 'bias'), ('decoder', 'layers', '0', 'encoder_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn_layer_norm', 'scale'), ('decoder', 'layers', '1', 'encoder_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'final_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('decoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'fc2', 'bias'), ('model', 'encoder', 'layers', '1', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '0', 'final_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('model', 'encoder', 'layers', '1', 'fc2', 'kernel'), ('model', 'encoder', 'layers', '0', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('encoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'final_layer_norm', 'kernel'), ('model', 'encoder', 'embed_positions', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layernorm_embedding', 'scale'), ('decoder', 'embed_positions', 'embedding'), ('decoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layernorm_embedding', 'bias'), ('classification_head', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'q_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '0', 'fc2', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('encoder', 'embed_positions', 'kernel'), ('encoder', 'layers', '1', 'fc1', 'bias'), ('encoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'final_layer_norm', 'bias'), ('qa_outputs', 'bias'), ('classification_head', 'out_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn', 'v_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn_layer_norm', 'scale'), ('decoder', 'layers', '1', 'encoder_attn', 'k_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'final_layer_norm', 'kernel'), ('qa_outputs', 'kernel'), ('classification_head', 'dense', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn_layer_norm', 'kernel'), ('encoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'v_proj', 'bias'), ('decoder', 'layers', '1', 'final_layer_norm', 'scale'), ('encoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('decoder', 'layers', '1', 'final_layer_norm', 'bias'), ('decoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'fc2', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn', 'q_proj', 'kernel'), ('classification_head', 'dense', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('decoder', 'layers', '1', 'fc1', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('encoder', 'layers', '0', 'self_attn_layer_norm', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel')}\n",
+      "- This IS expected if you are initializing FlaxBartForCausalLM from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing FlaxBartForCausalLM from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "You passed along `num_labels=3` with an incompatible id to label map: {0: 'LABEL_0', 1: 'LABEL_1'}. The number of labels wil be overwritten to 2.\n",
+      "Some weights of the model checkpoint at hf-internal-testing/tiny-random-wav2vec2 were not used when initializing FlaxWav2Vec2Model: {('quantizer', 'weight_proj', 'bias'), ('lm_head', 'bias'), ('project_q', 'bias'), ('quantizer', 'codevectors'), ('quantizer', 'weight_proj', 'kernel'), ('lm_head', 'kernel'), ('project_hid', 'bias'), ('project_q', 'kernel'), ('project_hid', 'kernel')}\n",
+      "- This IS expected if you are initializing FlaxWav2Vec2Model from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing FlaxWav2Vec2Model from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "Some weights of FlaxWav2Vec2Model were not initialized from the model checkpoint at hf-internal-testing/tiny-random-wav2vec2 and are newly initialized: {('feature_extractor', 'conv_layers', '2', 'layer_norm', 'bias'), ('feature_extractor', 'conv_layers', '1', 'layer_norm', 'scale'), ('feature_extractor', 'conv_layers', '2', 'layer_norm', 'scale'), ('feature_extractor', 'conv_layers', '1', 'layer_norm', 'bias')}\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n",
+      "You passed along `num_labels=3` with an incompatible id to label map: {'0': 'LABEL_0', '1': 'LABEL_1'}. The number of labels wil be overwritten to 2.\n",
+      "Some weights of the model checkpoint at hf-internal-testing/tiny-random-bart were not used when initializing FlaxBartForCausalLM: {('encoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('decoder', 'layers', '1', 'fc1', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn_layer_norm', 'scale'), ('model', 'encoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'final_layer_norm', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn_layer_norm', 'bias'), ('encoder', 'layers', '0', 'fc1', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('model', 'shared', 'kernel'), ('shared', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn_layer_norm', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'embed_tokens', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('final_logits_bias',), ('decoder', 'embed_tokens', 'embedding'), ('model', 'encoder', 'layernorm_embedding', 'kernel'), ('encoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn_layer_norm', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '1', 'fc2', 'bias'), ('encoder', 'embed_tokens', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'final_layer_norm', 'bias'), ('encoder', 'layernorm_embedding', 'kernel'), ('decoder', 'layers', '0', 'final_layer_norm', 'scale'), ('lm_head', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'final_layer_norm', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'out_proj', 'bias'), ('encoder', 'layers', '1', 'fc2', 'bias'), ('model', 'encoder', 'layers', '1', 'final_layer_norm', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('decoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'fc2', 'kernel'), ('decoder', 'layers', '0', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'fc1', 'kernel'), ('model', 'encoder', 'layernorm_embedding', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'k_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '1', 'fc2', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '0', 'fc2', 'kernel'), ('model', 'encoder', 'layers', '1', 'self_attn', 'out_proj', 'bias'), ('decoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn_layer_norm', 'scale'), ('encoder', 'layernorm_embedding', 'bias'), ('decoder', 'layers', '0', 'encoder_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn_layer_norm', 'scale'), ('decoder', 'layers', '1', 'encoder_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'final_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('decoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'fc2', 'bias'), ('model', 'encoder', 'layers', '1', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '0', 'final_layer_norm', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('model', 'encoder', 'layers', '1', 'fc2', 'kernel'), ('model', 'encoder', 'layers', '0', 'fc1', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('encoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'k_proj', 'kernel'), ('encoder', 'layers', '0', 'final_layer_norm', 'kernel'), ('model', 'encoder', 'embed_positions', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layernorm_embedding', 'scale'), ('decoder', 'embed_positions', 'embedding'), ('decoder', 'layers', '1', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'fc1', 'kernel'), ('decoder', 'layernorm_embedding', 'bias'), ('classification_head', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'v_proj', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'q_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('encoder', 'layers', '0', 'fc2', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'v_proj', 'bias'), ('encoder', 'embed_positions', 'kernel'), ('encoder', 'layers', '1', 'fc1', 'bias'), ('encoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'final_layer_norm', 'bias'), ('qa_outputs', 'bias'), ('classification_head', 'out_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn', 'v_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn_layer_norm', 'scale'), ('decoder', 'layers', '1', 'encoder_attn', 'k_proj', 'bias'), ('encoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'fc1', 'kernel'), ('decoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'self_attn', 'out_proj', 'kernel'), ('model', 'encoder', 'layers', '0', 'fc2', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'final_layer_norm', 'kernel'), ('qa_outputs', 'kernel'), ('classification_head', 'dense', 'bias'), ('decoder', 'layers', '1', 'encoder_attn', 'v_proj', 'kernel'), ('encoder', 'layers', '1', 'self_attn_layer_norm', 'kernel'), ('encoder', 'layers', '0', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '0', 'encoder_attn', 'v_proj', 'bias'), ('decoder', 'layers', '1', 'final_layer_norm', 'scale'), ('encoder', 'layers', '0', 'self_attn', 'k_proj', 'bias'), ('decoder', 'layers', '1', 'final_layer_norm', 'bias'), ('decoder', 'layers', '1', 'self_attn', 'q_proj', 'bias'), ('model', 'encoder', 'layers', '0', 'fc2', 'kernel'), ('decoder', 'layers', '1', 'encoder_attn', 'q_proj', 'kernel'), ('classification_head', 'dense', 'kernel'), ('encoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('decoder', 'layers', '1', 'fc1', 'bias'), ('model', 'encoder', 'layers', '0', 'self_attn', 'q_proj', 'bias'), ('encoder', 'layers', '0', 'self_attn_layer_norm', 'kernel'), ('decoder', 'layers', '0', 'encoder_attn', 'v_proj', 'kernel'), ('decoder', 'layers', '0', 'self_attn', 'out_proj', 'bias'), ('model', 'encoder', 'layers', '1', 'self_attn_layer_norm', 'bias'), ('decoder', 'layers', '1', 'self_attn', 'q_proj', 'kernel')}\n",
+      "- This IS expected if you are initializing FlaxBartForCausalLM from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing FlaxBartForCausalLM from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "You passed along `num_labels=3` with an incompatible id to label map: {0: 'LABEL_0', 1: 'LABEL_1'}. The number of labels wil be overwritten to 2.\n"
+     ]
+    }
+   ],
+   "source": [
+    "hf_model = FlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_from_pt=True, decoder_from_pt=True)\n",
+    "custom_model = CustomFlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_from_pt=True, decoder_from_pt=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fdadc85b-768d-46c7-aa26-01b1f93fd635",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create some dummy data\n",
+    "inputs = np.random.randn(2, 2000)\n",
+    "decoder_input_ids = np.arange(100).reshape(2,50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "caaff775-e082-419f-b737-b392667469d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get ground-truth outputs from Transformers 🤗 model\n",
+    "hf_outputs = hf_model(inputs, decoder_input_ids=decoder_input_ids, output_hidden_states=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1ff2be6b-73ef-49fc-8dbe-e933b5d4f8b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extract_features = custom_model.encode(inputs, output_features=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0e2b2d35-dee8-4c47-be35-e543b0f9ef03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_outputs = custom_model(inputs, extract_features=extract_features, decoder_input_ids=decoder_input_ids, output_hidden_states=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "aefb168b-4882-41f1-ba88-39f298835dac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define a helper function for our analysis\n",
+    "def assert_almost_equals(a: np.ndarray, b: np.ndarray, tol: float = 1e-9):\n",
+    "    diff = np.abs((a - b)).max()\n",
+    "    if diff <= tol:\n",
+    "        print(f\"✅ Difference between Flax and PyTorch is {diff} (< {tol})\")\n",
+    "    else:\n",
+    "        print(f\"❌ Difference between Flax and PyTorch is {diff} (>= {tol})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dea2f7c9-a462-40c1-b09b-7c8499318e87",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------Checking encoder hidden states match--------------------------\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "--------------------------Checking encoder last hidden states match--------------------------\n",
+      "HF output shape: (2, 29, 16), custom output shape: (2, 29, 16)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "--------------------------Checking decoder hidden states match--------------------------\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n",
+      "--------------------------Checking logits match--------------------------\n",
+      "HF logits shape: (2, 50, 1000), Custom logits shape: (2, 50, 1000)\n",
+      "✅ Difference between Flax and PyTorch is 0.0 (< 1e-09)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"--------------------------Checking encoder hidden states match--------------------------\")\n",
+    "for hf_state, custom_state in zip(hf_outputs.encoder_hidden_states, custom_outputs.encoder_hidden_states):\n",
+    "    assert hf_state.shape == custom_state.shape\n",
+    "    assert_almost_equals(hf_state, custom_state)\n",
+    "\n",
+    "print(\"--------------------------Checking encoder last hidden states match--------------------------\")\n",
+    "print(f\"HF output shape: {hf_outputs.encoder_last_hidden_state.shape}, custom output shape: {custom_outputs.encoder_last_hidden_state.shape}\")\n",
+    "assert_almost_equals(hf_outputs.encoder_last_hidden_state, custom_outputs.encoder_last_hidden_state)\n",
+    "\n",
+    "print(\"--------------------------Checking decoder hidden states match--------------------------\")\n",
+    "for hf_state, custom_state in zip(hf_outputs.decoder_hidden_states, custom_outputs.decoder_hidden_states):\n",
+    "    assert hf_state.shape == custom_state.shape\n",
+    "    assert_almost_equals(hf_state, custom_state)\n",
+    "\n",
+    "print(\"--------------------------Checking logits match--------------------------\")\n",
+    "print(f\"HF logits shape: {hf_outputs.logits.shape}, Custom logits shape: {custom_outputs.logits.shape}\")\n",
+    "assert_almost_equals(hf_outputs.logits, custom_outputs.logits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36f0a6f8-fc48-4326-bbaf-4ab5194f84a6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The feature encoder comprises of 6 convolutional layers that downsample the 16kHz audio inputs to the FlaxWav2Vec2 model to a sequence of latent speech representations. However, the feature encoder is frozen during training. Because of this, the gradients of the feature encoder parameters aren’t updated, and so the mapping from inputs -> hidden-states is entirely deterministic over the course of training.

We can anticipate a huge computational saving by passing the audio inputs through the feature encoder and then saving the hidden-state tensors (latent speech representations) after the first forward pass. We can then use these tensors as the inputs to the feature projection layer of the model, and run the model from there. This should also reduce the memory requirement of the model (skipping computing the intermediate hidden-states for the 6 convolutional layers) and should allow for a bigger batch size. 

This PR makes modifications to the modelling and training scripts, enabling saving of the outputs of the frozen feature extractor module in a partial forward pass to then be passed directly to the model during training.

There are two options for saving the feature encoder outputs:

1. Perform a partial forward pass prior to the first epoch. In this partial forward pass, only the feature encoder of the model is called and the feature encoder outputs saved. For all epochs during training, only a partial forward/backward pass is required from the feature encoder onwards.

- Compilation 1: partial forward pass (up to the feature encoder) before the first epoch
- Compilation 2: partial forward/backward pass (from the feature encoder onwards) in the first epoch

2. Save the feature encoder outputs as an auxiliary output during the first epoch, to then be used in subsequent epochs (i.e. epochs two onwards).

- Compilation 1: full forward/backward pass in the first epoch
- Compilation 2: partial forward/backward pass (from the feature encoder onwards) in the second epoch
I have provisionally settled on using the former of these two options. 

Both of these options require two stages of compilation, but the former should give a lower overall total compile time, only treating partial forward/backward passes.

Here are the results of benchmarking test that I ran.

Experimentation set-up:

- Training data: 5% of librispeech100

- Model: bart-large-cnn (had the infrastructure for bart-large-cnn ready so used this in the interest of time rather than bart-large -> not too important for this experiment as it's just the relative difference in train times that we're interested in, but will move all future experiments to bart-large now that the fp32 weights are available)

- Max input length: 10s
- Max target length: 64
- Num training examples: 251
- Num epochs: 5
- Per device batch size: 2
- Num gradient accumulation steps: 1 (kept this at 1 to avoid the extra compilation time that I currently encounter from using lax.fori_loop in my gradient accumulation implementation -> my next task once this is finished is to switch this to lax.scan which gives significantly reduced compile times)
- Total train batch size (w. parallel & distributed): 16
- Total optimization steps: 75
- Pad input to multiple of: 2s (giving a total of 3 compilation steps in the first epoch)
- No eval

Baseline results (no saving of feature encoder outputs):
Epoch 1 train time (compiling): 15m 17s
Epochs 2+ train time: 11s
Total train time: 16m 01s

Saved feature outputs:
Partial forward pass (compiling): 33s
Epoch 1 train time (compiling): 14m 24s
Epochs 2+ train time: 11s
Total train time: 15m 42s

So around a 6% speed-up.

Purely looking at per-device batch size increases (no gradient accumulation), saving the feature encoder output does not yield any larger batch size improvements over the baseline system:

1. Baseline (full precision, raw audio inputs): 2
2. Mixed precision: 4
3. Saved feature encoder outputs: 2
4. Mixed precision + saved feature encoder outputs: 4