### PR TITLE
Fix`train_metrics` bug in CTC script

### DIFF
--- a/run_flax_speech_recognition_ctc.py
+++ b/run_flax_speech_recognition_ctc.py
@@ -1151,8 +1151,8 @@ def main():
                     # need to upcast all device arrays to fp32 for wandb logging (jnp.bfloat16 not supported) -> do this here OR in train_step
                     write_wandb_log(to_fp32(train_metric), cur_step, prefix="train")
                     # we won't log to tensorboard for now (it is fiddly logging param and grad norms on a layer-by-layer basis)
-                    if has_tensorboard and jax.process_index() == 0:
-                        write_train_metric(summary_writer, train_metrics, train_time, cur_step)
+                    # if has_tensorboard and jax.process_index() == 0:
+                        # write_train_metric(summary_writer, train_metrics, train_time, cur_step)
 
                     epochs.write(
                         f"Step... ({cur_step} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']}, Gradient Norm: {train_metric['grad_norm']})"


### PR DESCRIPTION
When logging to TensorBoard, we continually append the device array `train_metric` to the list `train_metrics` over the course of training. When the number of logging steps is hit, we then log the list `train_metrics` to TensorBoard using the `SummaryWriter`. Currently, logging is performed exclusively to wandb. As such, the list `train_metrics` is not defined: holding the device arrays in this list can cause TPU OOM's, and so this list been dispensed with for the time being. This PR removes the inadvertent reference to `train_metrics`