### PR TITLE
Make CTC tokenizer `do_lower_case` attribute water-tight

### DIFF
--- a/run_flax_speech_recognition_ctc.py
+++ b/run_flax_speech_recognition_ctc.py
@@ -811,8 +811,13 @@ def main():
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
-        do_lower_case=False,
     )
+
+    if tokenizer.do_lower_case and data_args.dataset_name != "librispeech_asr":
+        raise ValueError("Setting the tokenizer attribute `do_lower_case` to `True` converts all input strings to "
+        "uppercase prior to tokenization. This should only be done when the tokenizer is built on an uppercased corpus,"
+        "i.e. for the dataset `librispeech_asr` only. If your dataset is not `librispeech_asr`, the tokenizer is mostly likely "
+        "built on an lowercased corpus. In this case, set `tokenizer.do_lower_case` to ``False`.")
 
     if training_args.precision == 'full_mixed':
         dtype = jnp.bfloat16


### PR DESCRIPTION
1. For the tokenizer, set `do_lower_case` to the value of `do_upper` (True/False) when the tokenizer is created: https://github.com/sanchit-gandhi/seq2seq-speech/blob/0ff54665154a476bcd741603250453709cc480c1/get_ctc_tokenizer.py#L268
2. When instantiating the tokenizer in the train script, do not specify `do_lower_case` -> `do_lower_case` will take the correct bool value assigned when the tokenizer is created
3. An `if` statement to ensure `tokenizer.do_lower_case` is set correctly

The Wav2Vec2 Librispeech tokenizer config has been updated accordingly: https://huggingface.co/speech-seq2seq/flax-wav2vec2-large-lv60-scan/commit/e9904676455f659b34ce9bb5f3c6f1c64eb4bcf3