### PR TITLE
[CTC] Enable removal of punctuation

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PublishConfigData" autoUpload="Always" remoteFilesAllowedToDisappearOnAutoupload="false">
+  <component name="PublishConfigData" autoUpload="Always" serverName="TRC" remoteFilesAllowedToDisappearOnAutoupload="false">
     <serverData>
       <paths name="patrick-tpu">
         <serverdata>


### PR DESCRIPTION
Enables removal of punctuation from the train, dev and test splits. If this fixes the negative CTC loss, we'll modify this to only strip punctuation from the training set.