### PR TITLE
[CTC] Remove unnecessary arg `ignore_mismatched_size`

### DIFF
--- a/run_flax_speech_recognition_ctc.py
+++ b/run_flax_speech_recognition_ctc.py
@@ -853,7 +853,6 @@ def main():
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
-        ignore_mismatched_sizes=True,  # ignore the mismatch in the LM head weights based on differences in tokenizer vocab size
     )
 
     # 6. Resample speech dataset ALWAYS


### PR DESCRIPTION
Setting `ignore_mismatched_size` to `True` is not required when loading the model from the randomly initialised weights at https://huggingface.co/speech-seq2seq/flax-wav2vec2-large-lv60-scan.