### PR TITLE
[Seq2Seq Train] Beam at each eval steps, greedy at end of epoch

### DIFF
--- a/run_flax_speech_recognition_seq2seq.py
+++ b/run_flax_speech_recognition_seq2seq.py
@@ -1424,7 +1424,7 @@ def main():
 
             if training_args.eval_steps == 0 and (epoch + 1) != num_epochs:
                 # run evaluation at the end of the epoch if eval steps are not specified
-                run_evaluation(cur_step, final_step=True)
+                run_evaluation(cur_step, final_step=False)
                 save_checkpoint(cur_step)
 
     if training_args.do_train:


### PR DESCRIPTION
Perform greedy at end of epoch, beam at each eval steps and final eval (whether evaluating at every epoch or after eval steps).