### PR TITLE
[prepare_dataset] Improve error correction vs normalisation

### DIFF
--- a/run_flax_speech_recognition_ctc.py
+++ b/run_flax_speech_recognition_ctc.py
@@ -973,10 +973,6 @@ def main():
             # convert spelled out punctuation to symbolic form
             for punctuation, replacement in gigaspeech_punctuation.items():
                 input_str = input_str.replace(punctuation, replacement)
-            if dataset_name == "speechcolab/gigaspeech" and len(input_str):
-                # for GS, we'll normalize the text to always finish with punctuation
-                if input_str[-1] not in [".", "?", "!"]:
-                    input_str = input_str + "."
 
         # SWB: hide the path to the private HF dataset
         if "switchboard" in dataset_name:

--- a/run_flax_speech_recognition_ctc_ngram.py
+++ b/run_flax_speech_recognition_ctc_ngram.py
@@ -1007,10 +1007,6 @@ def main():
             # convert spelled out punctuation to symbolic form
             for punctuation, replacement in gigaspeech_punctuation.items():
                 input_str = input_str.replace(punctuation, replacement)
-            if dataset_name == "speechcolab/gigaspeech" and len(input_str):
-                # for GS, we'll normalize the text to always finish with punctuation
-                if input_str[-1] not in [".", "?", "!"]:
-                    input_str = input_str + "."
 
         # SWB: hide the path to the private HF dataset
         if "switchboard" in dataset_name:

--- a/run_flax_speech_recognition_ctc_ngram.py
+++ b/run_flax_speech_recognition_ctc_ngram.py
@@ -924,8 +924,7 @@ def main():
     model_input_name = feature_extractor.model_input_names[0]
     do_lower_case = data_args.do_lower_case
     dataset_name = data_args.dataset_name
-    chars_to_ignore = ', ? . ! - ; : " “ % ‘ ” ?'.split(" ")
-    chars_to_ignore_regex = f'[{"".join(chars_to_ignore)}]'
+    tedlium_contractions = [" 's", " 't", " 're", " 've", " 'm", " 'll", " 'd", " 'clock", " 'all"]
     gigaspeech_punctuation = {" <comma>": ",", " <period>": ".", " <questionmark>": "?", " <exclamationpoint>": "!"}
     gigaspeech_disfluencies = ["<other>", "<sil>"]
     swb_disfluencies = ["[noise]", "[laughter]", "[silence]", "<a_aside>", "<b_aside>", "<e_aside>", "[laughter-",
@@ -946,99 +945,93 @@ def main():
         for split in test_split:
             raw_datasets[split] = raw_datasets[split].select(range(data_args.max_eval_samples))
 
-    if training_args.do_train and data_args.remove_punctuation:
-        def remove_punctuation(batch):
-            batch[text_column_name] = (
-                re.sub(chars_to_ignore_regex, "", batch[text_column_name]).replace("'", "").replace('"', "")
-            )
-
-        raw_datasets["train"] = raw_datasets["train"].map(
-            remove_punctuation,
-            num_proc=data_args.preprocessing_num_workers,
-            desc="removing punctuation from train split",
-        )
-
     # filter data where the targets are ignored in scoring
     def is_target_labels(input_str):
         return input_str.lower() not in ignore_segments
 
     raw_datasets = raw_datasets.filter(
-            is_target_labels,
-            num_proc=num_workers,
-            input_columns=[text_column_name],
-            desc="filtering data where the targets are ignored in scoring",
-        )
+        is_target_labels,
+        num_proc=num_workers,
+        input_columns=[text_column_name],
+        desc="filtering data where the targets are ignored in scoring",
+    )
 
     def prepare_dataset(batch):
-        # process audio
+        # pre-process audio
         try:
             sample = batch[audio_column_name]
         except ValueError:
+            # E22: some samples are empty (no audio). Reading the empty audio array will trigger
+            # a soundfile ValueError. For now, we'll manually set these arrays to a zero array.
+            # They will be filtered in the subsequent filtering stage and so are
+            # explicitly ignored during training.
             sample = {"array": np.array([0.]), "sampling_rate": feature_extractor.sampling_rate}
+
+        # normalise audio (mean, std) to (0, 1)
         inputs = feature_extractor(sample["array"], sampling_rate=sample["sampling_rate"])
         # process audio length
         batch[model_input_name] = inputs.input_values[0]
         batch["input_length"] = len(batch["input_values"])
 
-        # process targets
+        # 'error correction' of targets
         input_str = batch[text_column_name].lower() if do_lower_case else batch[text_column_name]
 
+        # LibriSpeech ASR
+        if dataset_name == "librispeech_asr":
+            pass  # no error correction necessary
+
+        # VoxPopuli
         if dataset_name == "google/xtreme_s":
-            # Finally, we tokenize the processed text
-            batch["labels"] = tokenizer(input_str).input_ids
-            batch["labels_length"] = len(batch["labels"])
-            return batch
+            pass  # no error correction necessary
 
         # Common Voice 9
-        if input_str.startswith('"') and input_str.endswith('"'):
-            # we can remove trailing quotation marks as they do not affect the transcription
-            input_str = input_str[1:-1]
-        # normalize quotation marks
-        input_str = re.sub(r'["“”]', '"', input_str)
-        # normalize apostrophes
-        input_str = re.sub(r"[’']", "'", input_str)
-        # normalize hyphens
-        input_str = re.sub(r"[—–]", "-", input_str)
-        # replace double quotation marks with single
-        input_str = input_str.replace('""', '"')
-        if dataset_name == "mozilla-foundation/common_voice_9_0" and len(input_str):
-            # for CV9, we'll normalize the text to always finish with punctuation
-            if input_str[-1] not in [".", "?", "!"]:
-                input_str = input_str + "."
+        if dataset_name == "mozilla-foundation/common_voice_9_0":
+            if input_str.startswith('"') and input_str.endswith('"'):
+                # we can remove trailing quotation marks as they do not affect the transcription
+                input_str = input_str[1:-1]
+            # replace double quotation marks with single
+            input_str = input_str.replace('""', '"')
 
-        # TEDLIUM-3
-        # delete the <unk> token from the text and replace spaced apostrophes with un-spaced
-        input_str = input_str.replace("<unk>", "").replace(" '", "'")
+        # TED-LIUM (Release 3)
+        if dataset_name == "LIUM/tedlium":
+            # delete the <unk> token from the text
+            input_str = input_str.replace("<unk>", "")
+            # replace spaced apostrophes with un-spaced (it 's -> it's)
+            for contraction in tedlium_contractions:
+                input_str = input_str.replace(contraction, contraction[1:])
 
         # GigaSpeech
-        for disfluency in gigaspeech_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # convert spelled out punctuation to symbolic form
-        for punctuation, replacement in gigaspeech_punctuation.items():
-            input_str = input_str.replace(punctuation, replacement)
-        if dataset_name == "speechcolab/gigaspeech" and len(input_str):
-            # for GS, we'll normalize the text to always finish with punctuation
-            if input_str[-1] not in [".", "?", "!"]:
-                input_str = input_str + "."
+        if dataset_name == "speechcolab/gigaspeech":
+            for disfluency in gigaspeech_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # convert spelled out punctuation to symbolic form
+            for punctuation, replacement in gigaspeech_punctuation.items():
+                input_str = input_str.replace(punctuation, replacement)
+            if dataset_name == "speechcolab/gigaspeech" and len(input_str):
+                # for GS, we'll normalize the text to always finish with punctuation
+                if input_str[-1] not in [".", "?", "!"]:
+                    input_str = input_str + "."
 
-        # SWB
-        for disfluency in swb_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # remove parenthesised text (test data only)
-        input_str = re.sub("[\(].*?[\)]", "", input_str)
-        for punctuation in swb_punctuations:
-            input_str = input_str.replace(punctuation, "")
-        # replace anomalous words with their correct transcriptions
-        split_str = input_str.split("/")
-        if len(split_str) > 1:
-            input_str = " ".join(
-                [" ".join([" ".join(i.split(" ")[:-1]) for i in split_str])] + [split_str[-1].split(" ")[-1]])
+        # SWB: hide the path to the private HF dataset
+        if "switchboard" in dataset_name:
+            for disfluency in swb_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # remove parenthesised text (test data only)
+            input_str = re.sub("[\(].*?[\)]", "", input_str)
+            for punctuation in swb_punctuations:
+                input_str = input_str.replace(punctuation, "")
+            # replace anomalous words with their correct transcriptions
+            split_str = input_str.split("/")
+            if len(split_str) > 1:
+                input_str = " ".join(
+                    [" ".join([" ".join(i.split(" ")[:-1]) for i in split_str])] + [split_str[-1].split(" ")[-1]])
 
-        # Earnings 22
-        for disfluency in earnings_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # replace mal-formatted ellipsis
-        input_str = input_str.replace("…", ".")
+        # Earnings 22: still figuring out best segmenting method. Thus, dataset name subject to change
+        if "earnings22" in dataset_name:
+            for disfluency in earnings_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # mal-formatted ellipsis used to denote an incomplete sentence, replace with ellipsis: … -> ...
+            input_str = input_str.replace("…", " . . . ")
 
         # JIWER compliance
         # remove multiple spaces

--- a/run_flax_speech_recognition_seq2seq.py
+++ b/run_flax_speech_recognition_seq2seq.py
@@ -964,10 +964,6 @@ def main():
             # convert spelled out punctuation to symbolic form
             for punctuation, replacement in gigaspeech_punctuation.items():
                 input_str = input_str.replace(punctuation, replacement)
-            if dataset_name == "speechcolab/gigaspeech" and len(input_str):
-                # for GS, we'll normalize the text to always finish with punctuation
-                if input_str[-1] not in [".", "?", "!"]:
-                    input_str = input_str + "."
 
         # SWB: hide the path to the private HF dataset
         if "switchboard" in dataset_name:

--- a/run_flax_speech_recognition_seq2seq.py
+++ b/run_flax_speech_recognition_seq2seq.py
@@ -881,6 +881,7 @@ def main():
     do_lower_case = data_args.do_lower_case
     log_first_ids = data_args.log_first_ids
     dataset_name = data_args.dataset_name
+    tedlium_contractions = [" 's", " 't", " 're", " 've", " 'm", " 'll", " 'd", " 'clock", " 'all"]
     gigaspeech_punctuation = {" <comma>": ",", " <period>": ".", " <questionmark>": "?", " <exclamationpoint>": "!"}
     gigaspeech_disfluencies = ["<other>", "<sil>"]
     swb_disfluencies = ["[noise]", "[laughter]", "[silence]", "<a_aside>", "<b_aside>", "<e_aside>", "[laughter-",
@@ -912,76 +913,82 @@ def main():
         )
 
     def prepare_dataset(batch):
-        # process audio
+        # pre-process audio
         try:
             sample = batch[audio_column_name]
         except ValueError:
+            # E22: some samples are empty (no audio). Reading the empty audio array will trigger
+            # a soundfile ValueError. For now, we'll manually set these arrays to a zero array.
+            # They will be filtered in the subsequent filtering stage and so are
+            # explicitly ignored during training.
             sample = {"array": np.array([0.]), "sampling_rate": feature_extractor.sampling_rate}
+
+        # normalise audio (mean, std) to (0, 1)
         inputs = feature_extractor(sample["array"], sampling_rate=sample["sampling_rate"])
         # process audio length
         batch[model_input_name] = inputs.input_values[0]
         batch["input_length"] = len(batch["input_values"])
         batch["input_id"] = batch[id_column_name] if log_first_ids else None
 
-        # process targets
+        # 'error correction' of targets
         input_str = batch[text_column_name].lower() if do_lower_case else batch[text_column_name]
 
+        # LibriSpeech ASR
+        if dataset_name == "librispeech_asr":
+            pass  # no error correction necessary
+
+        # VoxPopuli
         if dataset_name == "google/xtreme_s":
-            # Finally, we tokenize the processed text
-            batch["labels"] = tokenizer(input_str).input_ids
-            batch["labels_length"] = len(batch["labels"])
-            return batch
+            pass  # no error correction necessary
 
         # Common Voice 9
-        if input_str.startswith('"') and input_str.endswith('"'):
-            # we can remove trailing quotation marks as they do not affect the transcription
-            input_str = input_str[1:-1]
-        # normalize quotation marks
-        input_str = re.sub(r'["“”]', '"', input_str)
-        # normalize apostrophes
-        input_str = re.sub(r"[’']", "'", input_str)
-        # normalize hyphens
-        input_str = re.sub(r"[—–]", "-", input_str)
-        # replace double quotation marks with single
-        input_str = input_str.replace('""', '"')
-        if dataset_name == "mozilla-foundation/common_voice_9_0" and len(input_str):
-            # for CV9, we'll normalize the text to always finish with punctuation
-            if input_str[-1] not in [".", "?", "!"]:
-                input_str = input_str + "."
+        if dataset_name == "mozilla-foundation/common_voice_9_0":
+            if input_str.startswith('"') and input_str.endswith('"'):
+                # we can remove trailing quotation marks as they do not affect the transcription
+                input_str = input_str[1:-1]
+            # replace double quotation marks with single
+            input_str = input_str.replace('""', '"')
 
-        # TEDLIUM-3
-        # delete the <unk> token from the text and replace spaced apostrophes with un-spaced
-        input_str = input_str.replace("<unk>", "").replace(" '", "'")
+        # TED-LIUM (Release 3)
+        if dataset_name == "LIUM/tedlium":
+            # delete the <unk> token from the text
+            input_str = input_str.replace("<unk>", "")
+            # replace spaced apostrophes with un-spaced (it 's -> it's)
+            for contraction in tedlium_contractions:
+                input_str = input_str.replace(contraction, contraction[1:])
 
         # GigaSpeech
-        for disfluency in gigaspeech_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # convert spelled out punctuation to symbolic form
-        for punctuation, replacement in gigaspeech_punctuation.items():
-            input_str = input_str.replace(punctuation, replacement)
-        if dataset_name == "speechcolab/gigaspeech" and len(input_str):
-            # for GS, we'll normalize the text to always finish with punctuation
-            if input_str[-1] not in [".", "?", "!"]:
-                input_str = input_str + "."
+        if dataset_name == "speechcolab/gigaspeech":
+            for disfluency in gigaspeech_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # convert spelled out punctuation to symbolic form
+            for punctuation, replacement in gigaspeech_punctuation.items():
+                input_str = input_str.replace(punctuation, replacement)
+            if dataset_name == "speechcolab/gigaspeech" and len(input_str):
+                # for GS, we'll normalize the text to always finish with punctuation
+                if input_str[-1] not in [".", "?", "!"]:
+                    input_str = input_str + "."
 
-        # SWB
-        for disfluency in swb_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # remove parenthesised text (test data only)
-        input_str = re.sub("[\(].*?[\)]", "", input_str)
-        for punctuation in swb_punctuations:
-            input_str = input_str.replace(punctuation, "")
-        # replace anomalous words with their correct transcriptions
-        split_str = input_str.split("/")
-        if len(split_str) > 1:
-            input_str = " ".join(
-                [" ".join([" ".join(i.split(" ")[:-1]) for i in split_str])] + [split_str[-1].split(" ")[-1]])
+        # SWB: hide the path to the private HF dataset
+        if "switchboard" in dataset_name:
+            for disfluency in swb_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # remove parenthesised text (test data only)
+            input_str = re.sub("[\(].*?[\)]", "", input_str)
+            for punctuation in swb_punctuations:
+                input_str = input_str.replace(punctuation, "")
+            # replace anomalous words with their correct transcriptions
+            split_str = input_str.split("/")
+            if len(split_str) > 1:
+                input_str = " ".join(
+                    [" ".join([" ".join(i.split(" ")[:-1]) for i in split_str])] + [split_str[-1].split(" ")[-1]])
 
-        # Earnings 22
-        for disfluency in earnings_disfluencies:
-            input_str = input_str.replace(disfluency, "")
-        # replace mal-formatted ellipsis
-        input_str = input_str.replace("…", ".")
+        # Earnings 22: still figuring out best segmenting method. Thus, dataset name subject to change
+        if "earnings22" in dataset_name:
+            for disfluency in earnings_disfluencies:
+                input_str = input_str.replace(disfluency, "")
+            # mal-formatted ellipsis used to denote an incomplete sentence, replace with ellipsis: … -> ...
+            input_str = input_str.replace("…", " . . . ")
 
         # JIWER compliance
         # remove multiple spaces


### PR DESCRIPTION
Perform error correction of datasets on a dataset-by-dataset basis:

LibriSpeech ASR:
- No error correction necessary

VoxPopuli:
- No error correction necessary

Common Voice 9:
- Remove trailing quotation marks as they do not affect the transcription
- Replace double quotation marks with single
- <s>Normalise quotation marks, apostrophes, hyphens</s>
- <s>Normalise the text to always finish with punctuation</s>

TED-LIUM:
- Remove <unk> tokens
- Replace spaced apostrophes by un-spaced for most frequent instances (it 's -> it's)*

GigaSpeech:
- Remove junk tokens (disfluencies)
- Convert spelled out punctuation to symbolic (<comma> -> ,)
- <s>Normalise the text to always finish with punctuation</s>

SwitchBoard:
- Remove junk tokens (disfluencies)
- Remove parenthesised text detailing annotations (the cat sat on the (2) mat -> the cat sat on the mat)
- Replace anomalous words with their correct transcriptions: the cat/ca sat on the/th mat -> the cat sat on the mat

Earnings22:
- Remove junk tokens (disfluencies)
- Replace mal-formatted ellipsis with spaced (… -> . . . )

JIWER compliance (for WER/CER metrics):
- Remove multiple spaces
- Strip trailing spaces

<details>

<summary> *TED-LIUM contraction statistics </summary>

```
Contraction Occurrences
Total contractions in dataset: 120399
-----------------------------------------------------
     Cont. |       Total occ |       % of total occ |
-----------------------------------------------------
        's |           56216 |               46.691 |
        't |           22628 |               18.794 |
       're |           16658 |               13.836 |
       've |            9464 |                7.861 |
        'm |            8360 |                6.944 |
       'll |            3636 |                 3.02 |
        'd |            3259 |                2.707 |
    'clock |              75 |                0.062 |
      'all |              15 |                0.012 |
       'am |               7 |                0.006 |
   'ivoire |               4 |                0.003 |
    'grady |               4 |                0.003 |
    'neill |               4 |                0.003 |
    'brien |               3 |                0.002 |
     'oeil |               3 |                0.002 |
        'n |               3 |                0.002 |
    'alene |               3 |                0.002 |
    'arche |               2 |                0.002 |
        'a |               2 |                0.002 |
      'ivo |               2 |                0.002 |
      'ren |               2 |                0.002 |
     'ites |               2 |                0.002 |
   'connor |               2 |                0.002 |
       'an |               2 |                0.002 |
       'or |               2 |                0.002 |
       'ts |               2 |                0.002 |
     'dour |               2 |                0.002 |
      'tat |               2 |                0.002 |
     'hara |               2 |                0.002 |
   'aquila |               2 |                0.002 |
    'oreal |               1 |                0.001 |
     'oral |               1 |                0.001 |
   'agnese |               1 |                0.001 |
      'tre |               1 |                0.001 |
      'arc |               1 |                0.001 |
     'neal |               1 |                0.001 |
     'shea |               1 |                0.001 |
       'in |               1 |                0.001 |
      'lin |               1 |                0.001 |
  'gieblyn |               1 |                0.001 |
       'ed |               1 |                0.001 |
       'on |               1 |                0.001 |
        'i |               1 |                0.001 |
 'ospedale |               1 |                0.001 |
  'addaura |               1 |                0.001 |
   'reilly |               1 |                0.001 |
  'donohue |               1 |                0.001 |
 'donoghue |               1 |                0.001 |
      'ile |               1 |                0.001 |
  'foscari |               1 |                0.001 |
'herpiniere |               1 |                0.001 |
      'est |               1 |                0.001 |
   'conner |               1 |                0.001 |
  'oeuvres |               1 |                0.001 |
 'academie |               1 |                0.001 |
    'brian |               1 |                0.001 |
  'connell |               1 |                0.001 |
    'byrne |               1 |                0.001 |
   'angelo |               1 |                0.001 |
      'ant |               1 |                0.001 |
      'mun |               1 |                0.001 |
```

</details>